### PR TITLE
Changes to PacketData json format, New Decoder Package to handle the various packet layers.

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -1,0 +1,358 @@
+package decoder
+
+import (
+	"time"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
+
+type Payload struct {
+	Source      string
+	Destination string
+	Protocol    string
+	Length      int
+	Data        string
+}
+
+type NetworkType struct {
+	Version  uint8  `json:"version"`
+	Length   uint16 `json:"length"`
+	Id       uint16 `json:"id"`
+	TTL      uint8  `json:"ttl"`
+	Protocol string `json:"protocol"`
+	Checksum string `json:"checksum"`
+	SrcIP    string `json:"src_ip"`
+	DstIP    string `json:"dst_ip"`
+}
+
+type FlagType struct {
+	FIN, SYN, RST, PSH, ACK, URG, ECE, CWR, NS bool
+}
+
+type TCPTransportType struct {
+	Seq        uint32   `json:"seq"`
+	Ack        uint32   `json:"ack"`
+	DataOffset uint8    `json:"data_offset"`
+	Flags      FlagType `json:"flags"`
+	Window     uint16   `json:"window"`
+	Checksum   uint16   `json:"checksum"`
+	Urgent     uint16   `json:"urgent"`
+}
+
+type UDPTransportType struct {
+	Length uint16 `json:"length"`
+}
+
+type TransportType struct {
+	Type     string            `json:"type"`
+	SrcPort  string            `json:"src_port"`
+	DstPort  string            `json:"dst_port"`
+	Checksum string            `json:"checksum"`
+	Tcp      *TCPTransportType `json:"tcp"`
+	Udp      *UDPTransportType `json:"udp"`
+}
+
+type EthernetFrameType struct {
+	SrcMac string `json:"src_mac"`
+	DstMac string `json:"dst_mac"`
+}
+
+type CaptureInfo struct {
+	Timestamp      time.Time `json:"timestamp"`
+	CaptureLength  int       `json:"cap_length"`
+	Length         int       `json:"length"`
+	InterfaceIndex int       `json:"interface_index"`
+}
+
+type TLSRecordHeader struct {
+	ContentType string `json:"content_type"`
+	Version     string `json:"version"`
+	Length      uint16 `json:"length"`
+}
+
+type BaseRecord struct {
+	Header *TLSRecordHeader `json:"header"`
+}
+
+type AppRecord struct {
+	BaseRecord
+	Payload []byte `json:"payload"`
+}
+
+type CipherRecord struct {
+	BaseRecord
+	Message uint8 `json:"message"`
+}
+
+type HandshakeRecord struct {
+	BaseRecord
+}
+
+type TLSType struct {
+	ChangeCipherSpec *[]CipherRecord    `json:"change_cipher"`
+	Handshake        *[]HandshakeRecord `json:"handshake"`
+	AppData          *[]AppRecord       `json:"app_data"`
+}
+
+type ApplicationType struct {
+	TLS *TLSType
+}
+
+type PacketData struct {
+	Metadata      *CaptureInfo       `json:"metadata"`
+	EthernetFrame *EthernetFrameType `json:"ethernet"`
+	Network       *NetworkType       `json:"network"`
+	Transport     *TransportType     `json:"transport"`
+	Application   *ApplicationType   `json:"application"`
+}
+
+func DecodePacket(packet gopacket.Packet) (payload PacketData, _ error) {
+
+	var (
+		ethLayer layers.Ethernet
+		ipLayer  layers.IPv4
+		tcpLayer layers.TCP
+		udpLayer layers.UDP
+		tlsLayer layers.TLS
+		dnsLayer layers.DNS
+	)
+
+	parser := gopacket.NewDecodingLayerParser(
+		layers.LayerTypeEthernet,
+		&ethLayer,
+		&ipLayer,
+		&tcpLayer,
+		&tlsLayer,
+		&udpLayer,
+		&dnsLayer,
+	)
+
+	foundLayerTypes := []gopacket.LayerType{}
+
+	data := PacketData{}
+
+	err := parser.DecodeLayers(packet.Data(), &foundLayerTypes)
+
+	if err != nil {
+		return PacketData{}, err
+	}
+
+	nerr := packet.ErrorLayer()
+
+	if nerr != nil {
+		return PacketData{}, nerr.Error()
+	}
+
+	// Add Packet Metadata to payload
+	data.Metadata = getPacketMetadata(packet)
+
+	// Decode Ethernet data into data.EthernetFrame
+	DecodeEthernetFrame(&ethLayer, &data)
+
+	// Decode Network-Layer Data into data.Network
+	DecodeNetworkLayer(&ipLayer, &data)
+
+	if packet.TransportLayer() != nil {
+		src, dst := packet.TransportLayer().TransportFlow().Endpoints()
+		DecodeTransportLayer(src, dst, &udpLayer, &tcpLayer, &data, foundLayerTypes)
+
+		if packet.ApplicationLayer() != nil {
+			// Decode Application-Layer into data.Application
+			DecodeApplicationLayer(packet, &tlsLayer, &data, foundLayerTypes)
+		}
+	}
+
+	return data, nil
+}
+
+func getPacketMetadata(packet gopacket.Packet) *CaptureInfo {
+	cInfo := packet.Metadata().CaptureInfo
+	metadata := &CaptureInfo{
+		Timestamp:      cInfo.Timestamp,
+		CaptureLength:  cInfo.CaptureLength,
+		InterfaceIndex: cInfo.InterfaceIndex,
+		Length:         cInfo.Length,
+	}
+
+	return metadata
+}
+
+func DecodeEthernetFrame(ethLayer *layers.Ethernet, data *PacketData) {
+	if ethLayer != nil {
+		data.EthernetFrame = &EthernetFrameType{
+			SrcMac: ethLayer.SrcMAC.String(),
+			DstMac: ethLayer.DstMAC.String(),
+		}
+	}
+}
+
+func DecodeNetworkLayer(ipLayer *layers.IPv4, data *PacketData) {
+	if ipLayer != nil {
+		data.Network = &NetworkType{
+			SrcIP:    ipLayer.SrcIP.String(),
+			DstIP:    ipLayer.DstIP.String(),
+			Length:   ipLayer.Length,
+			Id:       ipLayer.Id,
+			TTL:      ipLayer.TTL,
+			Version:  ipLayer.Version,
+			Protocol: ipLayer.Protocol.String(),
+			Checksum: "dummy checksum",
+		}
+	}
+}
+
+func DecodeTransportLayer(src gopacket.Endpoint, dst gopacket.Endpoint, udpLayer *layers.UDP, tcpLayer *layers.TCP, data *PacketData, foundLayerTypes []gopacket.LayerType) {
+
+	tType := &TransportType{
+		SrcPort: src.String(),
+		DstPort: dst.String(),
+	}
+
+	for _, layerType := range foundLayerTypes {
+		switch layerType {
+		case layers.LayerTypeUDP:
+			tType.Type = "UDP"
+			tData := decodeUDP(udpLayer)
+			tType.Udp = tData
+		case layers.LayerTypeTCP:
+			tType.Type = "TCP"
+			tData := decodeTCP(tcpLayer)
+			tType.Tcp = tData
+		}
+	}
+
+	data.Transport = tType
+}
+
+func decodeTCP(tcpLayer *layers.TCP) *TCPTransportType {
+
+	if tcpLayer != nil {
+		return &TCPTransportType{
+			Window:     tcpLayer.Window,
+			Urgent:     tcpLayer.Urgent,
+			Seq:        tcpLayer.Seq,
+			Ack:        tcpLayer.Ack,
+			DataOffset: tcpLayer.DataOffset,
+			Flags: FlagType{
+				SYN: tcpLayer.SYN,
+				PSH: tcpLayer.PSH,
+				FIN: tcpLayer.FIN,
+				RST: tcpLayer.RST,
+				URG: tcpLayer.URG,
+				ECE: tcpLayer.ECE,
+				CWR: tcpLayer.CWR,
+				ACK: tcpLayer.ACK,
+			},
+		}
+	}
+
+	return nil
+}
+
+func decodeUDP(udpLayer *layers.UDP) *UDPTransportType {
+
+	if udpLayer != nil {
+		return &UDPTransportType{
+			Length: udpLayer.Length,
+		}
+	}
+
+	return nil
+}
+
+func getAppData(appData []layers.TLSAppDataRecord) []AppRecord {
+	appDataList := []AppRecord{}
+
+	for _, item := range appData {
+		appDataList = append(appDataList, AppRecord{
+			BaseRecord: BaseRecord{
+				Header: &TLSRecordHeader{
+					Version:     item.Version.String(),
+					Length:      item.Length,
+					ContentType: item.ContentType.String(),
+				},
+			},
+			Payload: item.Payload,
+		})
+	}
+
+	return appDataList
+}
+
+func getHandshakeData(handshakeRecord []layers.TLSHandshakeRecord) []HandshakeRecord {
+	appDataList := []HandshakeRecord{}
+
+	for _, item := range handshakeRecord {
+		appDataList = append(appDataList, HandshakeRecord{
+			BaseRecord: BaseRecord{
+				Header: &TLSRecordHeader{
+					Version:     item.Version.String(),
+					Length:      item.Length,
+					ContentType: item.ContentType.String(),
+				},
+			},
+		})
+	}
+
+	return appDataList
+}
+
+func getCipherData(cipherRecord []layers.TLSChangeCipherSpecRecord) []CipherRecord {
+	appDataList := []CipherRecord{}
+
+	for _, item := range cipherRecord {
+		appDataList = append(appDataList, CipherRecord{
+			BaseRecord: BaseRecord{
+				Header: &TLSRecordHeader{
+					Version:     item.Version.String(),
+					Length:      item.Length,
+					ContentType: item.ContentType.String(),
+				},
+			},
+			Message: uint8(item.Message),
+		})
+	}
+
+	return appDataList
+}
+
+func decodeTLS(tlsLayer *layers.TLS) *TLSType {
+	tlsData := &TLSType{}
+
+	appData := getAppData(tlsLayer.AppData)
+	handshakeData := getHandshakeData(tlsLayer.Handshake)
+	cipherData := getCipherData(tlsLayer.ChangeCipherSpec)
+
+	if len(appData) != 0 {
+		tlsData.AppData = &appData
+	}
+	if len(handshakeData) != 0 {
+		tlsData.Handshake = &handshakeData
+	}
+	if len(cipherData) != 0 {
+		tlsData.ChangeCipherSpec = &cipherData
+	}
+
+	return tlsData
+}
+
+func decodeDNS() {}
+
+func decodeHTTP() {}
+
+func DecodeApplicationLayer(packet gopacket.Packet, tlsLayer *layers.TLS, data *PacketData, foundLayerTypes []gopacket.LayerType) {
+
+	var application *ApplicationType = &ApplicationType{}
+
+	if tlsLayer != nil {
+		tlsData := decodeTLS(tlsLayer)
+		application.TLS = tlsData
+	}
+
+	// Check if TCP port is 80, decode as HTTP if there is data.
+
+	// Check if there is a DNS Layer too and decode it.
+
+	data.Application = application
+}

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -1,0 +1,409 @@
+package decoder
+
+import (
+	"encoding/hex"
+	"log"
+	"net"
+	"testing"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
+
+func getIPLayer() *layers.IPv4 {
+	return &layers.IPv4{
+		SrcIP:      net.IP{127, 0, 0, 1},
+		DstIP:      net.IP{8, 8, 8, 8},
+		Version:    4,
+		IHL:        5,
+		TOS:        0,
+		Id:         31873,
+		Length:     40,
+		Flags:      2,
+		FragOffset: 0,
+		TTL:        55,
+		Checksum:   8239,
+		Options:    nil,
+		Padding:    nil,
+	}
+}
+
+func getTCPLayer() *layers.TCP {
+	return &layers.TCP{
+		SrcPort:    layers.TCPPort(4321),
+		DstPort:    layers.TCPPort(80),
+		DataOffset: 5,
+		Seq:        497,
+		Ack:        1975,
+		FIN:        false,
+		SYN:        false,
+		RST:        false, PSH: false, ACK: true, URG: false, ECE: false, CWR: false, NS: false,
+		Window: 331,
+		Urgent: 0,
+	}
+}
+
+func getTLSLayer() *layers.TLS {
+	cipherRecord := layers.TLSChangeCipherSpecRecord{
+		Message: 1,
+		TLSRecordHeader: layers.TLSRecordHeader{
+			ContentType: 20,
+			Version:     0x0303,
+		},
+	}
+
+	return &layers.TLS{
+		ChangeCipherSpec: []layers.TLSChangeCipherSpecRecord{
+			cipherRecord,
+		},
+	}
+}
+
+func getUDPLayer() *layers.UDP {
+	return &layers.UDP{
+		SrcPort: layers.UDPPort(4000),
+		DstPort: layers.UDPPort(80),
+	}
+}
+
+func getEthernetLayer() *layers.Ethernet {
+	return &layers.Ethernet{
+		SrcMAC:       net.HardwareAddr{0xFF, 0xAA, 0xFA, 0xAA, 0xFF, 0xAA},
+		DstMAC:       net.HardwareAddr{0xBD, 0xBD, 0xBD, 0xBD, 0xBD, 0xBD},
+		EthernetType: 2048,
+	}
+}
+
+func getBaseLayers() (*layers.Ethernet, *layers.IPv4) {
+	ipLayer := getIPLayer()
+	ethernetLayer := getEthernetLayer()
+
+	return ethernetLayer, ipLayer
+}
+
+func constructPacket(
+	ethLayer *layers.Ethernet, ipLayer *layers.IPv4,
+	transportPacket interface{},
+) gopacket.Packet {
+	rawBytes := []byte{10, 20, 30}
+
+	// And create the packet with the layers
+	buffer := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{}
+	gopacket.SerializeLayers(buffer, opts,
+		ethLayer,
+		ipLayer,
+		transportPacket.(gopacket.SerializableLayer),
+		gopacket.Payload(rawBytes),
+	)
+	outgoingPacket := buffer.Bytes()
+
+	ethpacket := gopacket.NewPacket(outgoingPacket,
+		layers.LayerTypeEthernet,
+		gopacket.Default)
+
+	return ethpacket
+}
+
+func constructTLSPacket() gopacket.Packet {
+	const tlsHexDump = "b41c30c04592c4d987861a0f080045000068e5f340004006ba19c0a8008e6812713ac03401bb3cc11691112fcc5d501801f5599d000014030300010117030300351ffacbf291a466c16a56ef949cebace34c97dc1052697342de5e9723a6e0dcc312a684da4c5e7383230cec94c097857df8a76c1620"
+
+	// TLS HexDump Data
+	// Ethernet data
+	// dst --> b4:1c:30:c0:45:92
+	// src --> c4:d9:87:86:1a:0f
+
+	// IPv4 data
+	// src --> 192.168.0.142
+	// dst --> 104.18.113.58
+	// Protocol --> TCP
+	// TTL --> 64
+	// Id --> 58867
+
+	// TCP data
+	// src --> 49204
+	// dst --> 443
+	// PSH --> true ; ACK --> true
+	// Window --> 501
+	// Urgent --> 0
+
+	// TLS data
+	// Record Layers (2)
+	// 1. Change Cipher Spec Protocol --> Change Cipher Spec
+	// 		Content-Type --> 20
+	// 		Version --> TLS 1.2
+	// 		Length --> 1
+	// 		Message --> 1
+	// 2. Application Data Protocol --> http-over-tls
+	// 		Content-Type --> 23
+	// 		Version --> TLS 1.2
+	// 		Length --> 53
+	// 		Payload --> hexdump of byte payload
+
+	data, err := hex.DecodeString(tlsHexDump)
+
+	if err != nil {
+		panic(err)
+	}
+
+	ethpacket := gopacket.NewPacket(data,
+		layers.LayerTypeEthernet,
+		gopacket.Default)
+
+	return ethpacket
+}
+
+func constructUDPPacket() gopacket.Packet {
+
+	ethLayer, ipLayer := getBaseLayers()
+	ipLayer.Protocol = layers.IPProtocolUDP
+	udpLayer := getUDPLayer()
+
+	return constructPacket(ethLayer, ipLayer, udpLayer)
+}
+
+func constructTCPpacket() gopacket.Packet {
+
+	ethLayer, ipLayer := getBaseLayers()
+	ipLayer.Protocol = layers.IPProtocolTCP
+	tcpLayer := getTCPLayer()
+	return constructPacket(ethLayer, ipLayer, tcpLayer)
+}
+
+func TestDecodeEthernetFrame(t *testing.T) {
+	packet := constructTCPpacket()
+
+	layer := packet.Layer(layers.LayerTypeEthernet)
+	ethLayer := layer.(*layers.Ethernet)
+
+	data := PacketData{}
+
+	DecodeEthernetFrame(ethLayer, &data)
+
+	t.Run("test data is updated with ethernet data", func(t *testing.T) {
+		ethFrame := data.EthernetFrame
+		if ethFrame.SrcMac != "ff:aa:fa:aa:ff:aa" {
+			t.Errorf("source mac address does not exist.")
+		}
+
+		if ethFrame.DstMac != "bd:bd:bd:bd:bd:bd" {
+			t.Errorf("destination mac address does not exist.")
+		}
+	})
+}
+
+func TestDecodeNetworkLayer(t *testing.T) {
+	packet := constructTCPpacket()
+
+	t.Run("test data contains ip packet data", func(t *testing.T) {
+
+		layer := packet.Layer(layers.LayerTypeIPv4)
+		ipLayer := layer.(*layers.IPv4)
+
+		data := PacketData{}
+
+		DecodeNetworkLayer(ipLayer, &data)
+
+		ipData := data.Network
+
+		if ipData == nil {
+			t.Errorf("IP data not found")
+		}
+
+		if ipData.SrcIP != "127.0.0.1" {
+			t.Errorf("source ip address not found.")
+		}
+
+		if ipData.DstIP != "8.8.8.8" {
+			t.Errorf("destination ip address not found.")
+		}
+
+		if ipData.Protocol != "TCP" {
+			t.Errorf("protocol invalid for ip data")
+		}
+	})
+
+	t.Run("test that network section for data returns nil if iplayer is nil", func(t *testing.T) {
+		data := PacketData{}
+
+		DecodeNetworkLayer(nil, &data)
+
+		if data.Network != nil {
+			t.Errorf("network section should return nil.")
+		}
+	})
+}
+
+func TestDecodeTransportLayer(t *testing.T) {
+
+	t.Run("test data contains tcp packet data", func(t *testing.T) {
+		packet := constructTCPpacket()
+		layer := packet.Layer(layers.LayerTypeTCP)
+		tcpLayer := layer.(*layers.TCP)
+
+		layerTypes := []gopacket.LayerType{layers.LayerTypeTCP}
+
+		data := PacketData{}
+
+		src, dst := packet.TransportLayer().TransportFlow().Endpoints()
+
+		DecodeTransportLayer(src, dst, nil, tcpLayer, &data, layerTypes)
+
+		if data.Transport == nil {
+			t.Errorf("Transport section not found")
+		}
+
+		port := "4321"
+		tType := "TCP"
+
+		if data.Transport.Type != tType {
+			t.Errorf("Unexpected transport type, expected TCP")
+		}
+
+		if data.Transport.SrcPort != port {
+			t.Errorf("Unexpected source port for TCP transport")
+		}
+
+	})
+
+	t.Run("test data contains udp packet data", func(t *testing.T) {
+		packet := constructUDPPacket()
+		layer := packet.Layer(layers.LayerTypeUDP)
+		udpLayer := layer.(*layers.UDP)
+
+		layerTypes := []gopacket.LayerType{layers.LayerTypeUDP}
+
+		data := PacketData{}
+
+		src, dst := packet.TransportLayer().TransportFlow().Endpoints()
+
+		DecodeTransportLayer(src, dst, udpLayer, nil, &data, layerTypes)
+
+		if data.Transport == nil {
+			t.Errorf("Transport section not found")
+		}
+
+		port := "4000"
+		tType := "UDP"
+
+		if data.Transport.Type != tType {
+			t.Errorf("Unexpected transport type, expected UDP")
+		}
+
+		if data.Transport.SrcPort != port {
+			t.Errorf("Unexpected source port for UDP transport")
+		}
+
+	})
+}
+
+func TestDecodePacket(t *testing.T) {
+	packet := constructTCPpacket()
+
+	payload, err := DecodePacket(packet)
+
+	if err != nil {
+		panic(err)
+	}
+
+	t.Run("test for known nil fields", func(t *testing.T) {
+		application := payload.Application
+		if application != nil {
+			t.Errorf("test for application layer failed, expected nil value got %v", application)
+		}
+	})
+
+	t.Run("check for ethernet data", func(t *testing.T) {
+		got := payload.EthernetFrame.SrcMac
+		expected := "ff:aa:fa:aa:ff:aa"
+		if got != expected {
+			t.Errorf("test for ethernet layer failed, Source Mac Addresses do not match.")
+		}
+	})
+
+	t.Run("check for ip data", func(t *testing.T) {
+		got := payload.Network.SrcIP
+		log.Println(got)
+		expected := "127.0.0.1"
+		if got != expected {
+			t.Errorf("test for ip layer failed, IP addresses do not match")
+		}
+	})
+
+	t.Run("check for TCP data", func(t *testing.T) {
+		got := payload.Transport.SrcPort
+		expected := "4321"
+		if got != expected {
+			t.Errorf("test for tcp layer failed, Source Ports do not match")
+		}
+	})
+}
+
+func TestDecodePacketTLS(t *testing.T) {
+	packet := constructTLSPacket()
+
+	payload, err := DecodePacket(packet)
+	if err != nil {
+		panic(err)
+	}
+
+	t.Run("test for AppData record", func(t *testing.T) {
+		appRecord := (*payload.Application.TLS.AppData)[0]
+
+		header := appRecord.Header
+
+		if header.ContentType != "Application Data" {
+			t.Errorf("Content-Type does not match for app record.")
+		}
+
+		if header.Length != 53 {
+			t.Errorf("Header length does not match.")
+		}
+
+		if header.Version != "TLS 1.2" {
+			t.Errorf("Version does not match.")
+		}
+	})
+
+	t.Run("test for ChangeCipherSpec record", func(t *testing.T) {
+		cipherRecord := (*payload.Application.TLS.ChangeCipherSpec)[0]
+
+		header := cipherRecord.Header
+		message := cipherRecord.Message
+
+		// Test for ApplicationData record
+		if header.ContentType != "Change Cipher Spec" {
+			t.Errorf("Content-Type does not match for cipher spec record.")
+		}
+
+		if header.Length != 1 {
+			t.Errorf("Header length does not match.")
+		}
+
+		if header.Version != "TLS 1.2" {
+			t.Errorf("Version does not match.")
+		}
+
+		// Test for ChangeCipherSpec record
+		if message != 1 {
+			t.Errorf("Message value does not match")
+		}
+	})
+}
+
+func TestErrorDecodePacket(t *testing.T) {
+
+	t.Run("test that packet is empty", func(t *testing.T) {
+		emptyPacket := []byte{}
+
+		ethpacket := gopacket.NewPacket(emptyPacket,
+			layers.LayerTypeEthernet,
+			gopacket.Default)
+
+		_, err := DecodePacket(ethpacket)
+
+		if err == nil {
+			t.Errorf("Error decoding Ethernet packet")
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/Geeker1/gosniff/decoder"
 	"github.com/Geeker1/gosniff/json"
 	"github.com/Geeker1/gosniff/packets"
 	"github.com/gorilla/mux"
@@ -19,7 +20,7 @@ type JsonMessage struct {
 	Message string
 }
 
-var packetChan = make(chan packets.PacketsData)
+var packetChan = make(chan decoder.PacketData)
 var c = make(chan string)
 
 var upgrader = websocket.Upgrader{

--- a/main.go
+++ b/main.go
@@ -27,10 +27,6 @@ var upgrader = websocket.Upgrader{
 	WriteBufferSize: 1024,
 }
 
-func handleHome(w http.ResponseWriter, r *http.Request) {
-	json.SendJson(w, "Working root endppoint of the packet sniffer")
-}
-
 func getActiveInterfaces(w http.ResponseWriter, r *http.Request) {
 	pcapHandler := &packets.PcapHandler{}
 	devs, err := pcapHandler.FindAllDevs()
@@ -49,9 +45,15 @@ func getActiveInterfaces(w http.ResponseWriter, r *http.Request) {
 
 func startSniffer(w http.ResponseWriter, r *http.Request) {
 	var chosenInterfaces []string
-	json.GetJson(r, &chosenInterfaces)
 
-	json.SendJson(w, JsonMessage{Message: "Recieved"})
+	conn, _ := upgrader.Upgrade(w, r, nil)
+
+	err := conn.ReadJSON(&chosenInterfaces)
+
+	if err != nil {
+		log.Println("Error reading JSON from connection.", err)
+		conn.Close()
+	}
 
 	pcapHandler := &packets.PcapHandler{}
 	pcapMessage := &packets.SniffMessage{
@@ -61,26 +63,10 @@ func startSniffer(w http.ResponseWriter, r *http.Request) {
 		go packets.StartPacketSniffing(pcapHandler, i, pcapMessage)
 	}
 
-	if <-c == "kill" {
-		log.Println("Kill message recieved... stopped packet sniffing")
-	}
-}
-
-func recievePackets(w http.ResponseWriter, r *http.Request) {
-	conn, _ := upgrader.Upgrade(w, r, nil)
-
 	for {
 		packet := <-packetChan
-
-		// conn.WriteMessage(1, []byte(fmt.Sprintf("%v", result)))
 		conn.WriteJSON(packet)
 	}
-}
-
-func killPackets(w http.ResponseWriter, r *http.Request) {
-	log.Println("Recieve kill signal")
-	c <- "kill"
-	json.SendJson(w, JsonMessage{Message: "Done"})
 }
 
 func main() {
@@ -89,11 +75,8 @@ func main() {
 
 	r := mux.NewRouter()
 
-	r.HandleFunc("/", handleHome).Methods("GET")
 	r.HandleFunc("/active-interfaces", getActiveInterfaces).Methods("GET")
-	r.HandleFunc("/start-sniffer", startSniffer).Methods("POST")
-	r.HandleFunc("/recieve-packets", recievePackets).Methods("GET")
-	r.HandleFunc("/kill-packets", killPackets).Methods("POST")
+	r.HandleFunc("/start-sniffer", startSniffer)
 
 	log.Println("Application listening on port ", port)
 	http.ListenAndServe(":"+port, r)

--- a/packets/pcap_test.go
+++ b/packets/pcap_test.go
@@ -3,6 +3,7 @@ package packets
 import (
 	"testing"
 
+	"github.com/Geeker1/gosniff/decoder"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/pcap"
 )
@@ -35,11 +36,11 @@ func (pH *PcapHandlerTest) createPacketSource(handler *pcap.Handle) *gopacket.Pa
 	return &gopacket.PacketSource{}
 }
 
-func (pH *PcapHandlerTest) getPacketData(packet gopacket.Packet) PacketsData {
-	return PacketsData{
-		Dst: "192.168.0.0.1",
-		Src: "193.553.6.7.1",
-	}
+func (pH *PcapHandlerTest) getPacketData(packet gopacket.Packet) (decoder.PacketData, error) {
+	return decoder.PacketData{
+		// Dst: "192.168.0.0.1",
+		// Src: "193.553.6.7.1",
+	}, nil
 }
 
 func TestCheckForDevice(t *testing.T) {


### PR DESCRIPTION
Aim of this change is to update previous format of PacketData struct to handle new decoded layer types.

New PacketData format has the following structure.

```
type PacketData struct {
	Metadata      *CaptureInfo       `json:"metadata"`
	EthernetFrame *EthernetFrameType `json:"ethernet"`
	Network       *NetworkType       `json:"network"`
	Transport     *TransportType     `json:"transport"`
	Application   *ApplicationType   `json:"application"`
}
```
This represents the TCP/IP model with inclusion of extra fields, Metadata and EthernetFrame.
Metadata contains extra information on each packet, such as the Timestamp, interface_index, Length and Capture Length.
EthernetFrame contains information on the network_interface layer.

Decoder Package handles decoding of packet data into various layers

- network
- transport
- application

Currently supported application types are
- TLS

Types to be added --> DNS, HTTP

**Tests**
- Test Ethernet Frame properly decoded
- Test that Network Layer contains ip packet
- Test that Transport Layer contains udp packet and tcp packet.
- Test that TLS layer works successfully

